### PR TITLE
Set up daemon and nginx configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 deploy:
 	lsyncd deploy/lsyncd.conf.lua
 
-.PHONY: deploy
+install:
+	sudo bash deploy/install.sh
+
+.PHONY: deploy install

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 deploy:
 	lsyncd deploy/lsyncd.conf.lua
 
+run: activate
+	FLASK_APP=app.py FLASK_DEBUG=1 flask run
+
 install:
 	sudo bash deploy/install.sh
 
-.PHONY: deploy install
+activate:
+	. venv/bin/activate
+
+.PHONY: deploy install run

--- a/deploy/flicr.service
+++ b/deploy/flicr.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Job that runs the flicr daemon
+
+[Service]
+Type=simple
+WorkingDirectory=/home/pi/server
+ExecStart=/bin/sh -c "FLASK_APP=app.py FLASK_DEBUG=1 /home/pi/venv/bin/flask run"
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [[ "$EUID" -ne 0 ]]
+  then echo "Please run with sudo"
+  exit
+fi
+
+systemctl stop flicr
+cp deploy/flicr.service /lib/systemd/system
+systemctl daemon-reload
+systemctl enable flicr
+systemctl start flicr
+
+cp deploy/joe.local /etc/nginx/sites-available
+ln -s ../sites-available/joe.local /etc/nginx/sites-enabled/joe.local
+systemctl restart nginx
+systemctl status nginx

--- a/deploy/joe.local
+++ b/deploy/joe.local
@@ -1,0 +1,22 @@
+server {
+
+    server_name joe.local;
+
+	location / {
+		proxy_pass http://localhost:5000/;
+	}
+
+    listen 443 ssl;
+    include snippets/snakeoil.conf;
+
+}
+server {
+    if ($host = joe.local) {
+        return 301 https://$host$request_uri;
+    }
+
+    server_name joe.local;
+    listen 80;
+    return 404;
+
+}

--- a/server.iml
+++ b/server.iml
@@ -3,7 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 3.7 virtualenv" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.7 (Capstone)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>


### PR DESCRIPTION
Sets up systemd unit file to run the flask app as a daemon with auto-reloading

Sets up nginx configuration to proxy https requests to the flask app running http on port 5000